### PR TITLE
Add initial docs for configuring CFs.

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -21,10 +21,59 @@ and a backing set of custom resource definitions (CRDs) and custom controllers.
 
 To install and configure <%= vars.product_short %>:
 
+* [Create Cloud Foundry UAA client](#create-cf-uaa-client)
 * [Install Duffle](#install-duffle)
 * [Relocate images](#relocate)
 * [Install the CNAB](#install-cnab)
 * [Install the <%= vars.product_abbr %> CLI tool](#install-cli), which is needed for operating <%= vars.product_short %>.
+
+### <a id='create-cf-uaa-client'></a> Create Cloud Foundry UAA Client
+
+Note: This step is only required if you wish to bind service instances to
+applications running in Cloud Foundry. It must be repeated for each Cloud
+Foundry you wish to make availble to <%= vars.product_short %>.
+
+To create the required UAA Client:
+
+<%# The following steps are generic and have been copied from https://docs.pivotal.io/pks/1-6/manage-users.html %>
+
+1. Retrieve the UAA management admin client secret:
+  a. In a web browser, navigate to the Ops Manager Installation Dashboard and click the Pivotal Application Service tile.
+  b. Click the Credentials tab.
+  c. Click Link to Credential next to Admin Client Credentials and copy the value of `password`
+
+2.Target the Cloud Foundry UAA server by running the following command:
+
+    ```
+    uaac target https://UAA-ENDPOINT --ca-cert CERTIFICATE-PATH
+    ```
+
+Where:
+
+* `UAA-ENDPOINT` is the URL of the Cloud Foundry UAA server.
+* `CERTIFICATE-PATH` is the path to your Ops Manager root CA certificate.
+  * If you are logged in to the Ops Manager VM, specify `/var/tempest/workspaces/default/root_ca_certificate` as the path.
+  * This is the default location of the root certificate on the Ops Manager VM.
+  * If you downloaded the Ops Manager root CA certificate to your machine, specify the path where you stored the certificate.
+
+3. Authenticate with UAA by running the following command:
+
+    ```
+    uaac token client get admin -s ADMIN-CLIENT-SECRET
+    ```
+
+Where `ADMIN-CLIENT-SECRET` is your UAA management admin client secret that you
+retrieved in a previous step. The client username is admin.
+
+<%# The following steps are specific %>
+
+4. Create an admin client for <%= vars.product_short %>
+
+    ```
+    uaac client add developerconsole -s CLIENT_SECRET --authorized_grant_types client_credentials --authorities cloud_controller.admin
+    ```
+
+Where `CLIENT_SECRET` is a password of your choosing. Keep this password safe as it will be required when installing <%= developerconsole %>.
 
 ### <a id='install-duffle'></a> Install Duffle
 

--- a/using-providing.html.md.erb
+++ b/using-providing.html.md.erb
@@ -6,7 +6,7 @@ owner: Marketplace
 <strong><%= modified_date %></strong>
 
 This topic describes how to use <%= vars.product_full %> (<%= vars.product_abbr %>) to provide services to
-app teams and isolate different projects.
+app teams, how to provide isolation of resources via projects and how to register Cloud Foundry instances.
 
 ## <a id='overview'></a> Overview
 
@@ -16,6 +16,10 @@ Operators are then able to add or remove app team members to and from these proj
 
 The entities in a project map can be any of the base Kubernetes entities -- users, groups, and
 ServiceAccounts.
+
+In order to allow app teams to bind service instances to their apps that are
+running in Cloud Foundry, you must first register the Cloud Foundry in <%=
+vars.product_short %>.
 
 ## <a id='config-projects'></a> Configuring Projects
 
@@ -55,6 +59,41 @@ To create a new project:
 
     ```
       kubectl create -f project.yaml
+    ```
+
+## <a id='register-cfs'></a> Registering Cloud Foundries
+
+You can register Cloud Foundry deployments by posting YAML to the Kubernetes API of your cluster.
+This topic demonstrates this with the Kubernetes command line interface (CLI) tool, kubectl, which is one of
+several means of communicating with the API.
+To create register a new Cloud Foundry:
+
+1. Create a file called `cf.yaml` anywhere on your local machine.
+1. Copy and paste the contents below into the file.
+
+    ```yaml
+    apiVersion: developerconsole.pivotal.io/v1alpha1
+    kind: CloudFoundry
+    metadata:
+      name: CLOUDFOUNDRY-NAME
+    spec:
+      api: https://CLOUDFOUNDRY-API
+    ```
+
+    Where:
+    * `CLOUDFOUNDRY-NAME` is the name of the Cloud Foundry deployment you are registering. This can be anything you like.
+    * `CLOUDFOUNDRY-API` is the API endpoint of the Cloud Foundry. Note that the API endpoint must be accessible over the network from your cluster.
+
+1. Replace the placeholders with real values and save the file.
+
+    <p class="note">
+      <strong>Note:</strong> You must configure an admin client in the Cloud Foundry UAA, see [Create Cloud Foundry UAA client](#create-cf-uaa-client).
+    </p>
+
+1. Apply the configuration by running:
+
+    ```
+      kubectl create -f cf.yaml
     ```
 
 ## <a id='register-broker'></a> Register a Broker


### PR DESCRIPTION
Hey docs team,

This is an inital pass at adding some new docs for configuraing and registering Cloud Foundries with developer-console. These docs are "Alana/Operator" focused. I will open a seperate PR for the corresponding "Cody/Developer" docs. 

Note that a large part of the `Create Cloud Foundry UAA Client` docs were copied and slight modified from here: https://docs.pivotal.io/pks/1-6/manage-users.html.

Also a large part of the `Registering Cloud Foundries` is copied from the section above on `Configuring Projects`.

Thanks!
Ed