### PR TITLE
Remove Pivotal from the long form name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Always make changes you want carried forward in the master branch. This includes
 | alpha     | v0.2 (staged here: http://docs.pivotal.io/developer-console/0-alpha/|
 
 When the latest alpha version is ready to publish, merge the master branch into the alpha branch.
-Keep all the alpha versions of the release notes stacked in the [Release Notes for Pivotal Developer Console](https://docs.pivotal.io/developer-console/0-alpha/release-notes.html) page.
+Keep all the alpha versions of the release notes stacked in the [Release Notes for Developer Console](https://docs.pivotal.io/developer-console/0-alpha/release-notes.html) page.
 
 1. Always cherry-pick any changes to live branches into **master** if you want those changes carried forward.
 2. If necessary, immediately cherry-pick/copy changes from **master** that you want to push immediately to production into the appropriate live branch above."
@@ -37,7 +37,7 @@ We need to decide on product name short forms:
 
 | Term or product name | Notes |
 |----------------------|-------|
-|Pivotal Developer Console | `product_full`, the longest name |
+|Developer Console | `product_full`, the longest name |
 |Developer Console     | `product_short`, the short name, use on the page after the long name has been used |
 |PDC                   | `product_abbr`, use only where really necessary |
 |PDC CLI tool          | Name of the CLI tool, use instead of "`pdc` CLI tool"|

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pivotal Developer Console
+# Developer Console
 
 ## Where is the book repo?
 https://github.com/pivotal-cf/docs-book-developer-console

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Pivotal Developer Console (Alpha)
+title: Developer Console (Alpha)
 owner: Marketplace
 ---
 
@@ -15,7 +15,7 @@ owner: Marketplace
   <strong>Note:</strong> This product is only available to members of the <%= vars.product_short %>
   Early Adopter Program.
   For more information, please email
-  <a href="mailto:pdc-feedback@pivotal.io"><%= vars.product_abbr %> Feedback</a>.
+  <a href="mailto:pdc-feedback@pivotal.io"><%= vars.product_short %> Feedback</a>.
 </p>
 
 This documentation describes <%= vars.product_full %> (<%= vars.product_abbr %>).

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Installing and Configuring Pivotal Developer Console
+title: Installing and Configuring Developer Console
 owner: Marketplace
 ---
 
@@ -207,7 +207,7 @@ If you do not have an Early Access account, please email
 <%= vars.product_short %> is currently only available to Early Access users.
 
 1. Download the <%= vars.product_short %> tarball files from
-[Pivotal Network](https://network.pivotal.io/products/pivotal-developer-console/) to your working directory.
+[Pivotal Network](https://network.pivotal.io/products/developer-console/) to your working directory.
 
 1. Untar the `pdc` tarball and choose the appropriate binary CLI tool for your operating system.
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Release Notes for Pivotal Developer Console
+title: Release Notes for Developer Console
 owner: Marketplace
 ---
 

--- a/using-providing.html.md.erb
+++ b/using-providing.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Using Pivotal Developer Console to Provide Services
+title: Using Developer Console to Provide Services
 owner: Marketplace
 ---
 

--- a/using-provisioning.html.md.erb
+++ b/using-provisioning.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Using Pivotal Developer Console to Provision Services
+title: Using Developer Console to Provision Services
 owner: Marketplace
 ---
 


### PR DESCRIPTION
This is a follow on from a conversation with the brand-merge folks: https://pivotal.slack.com/archives/CSLPTCREU/p1583756877154300

Note: We haven't got a replacement acronym so for now the CLI tool and CNBAB bundle are still named PDC and we shouldn't use the acronym in other circumstances

Associated tracker story: https://www.pivotaltracker.com/story/show/171699346