### PR TITLE
Correct the spec fields for cloudfoundry space entitlements

### DIFF
--- a/using-providing.html.md.erb
+++ b/using-providing.html.md.erb
@@ -146,7 +146,8 @@ To create a new Cloud Foundry space entitlement:
       name: CLOUD-FOUNDRY-SPACE-ENTITLEMENT-NAME
     spec:
       namespace: PROJECT-NAME
-      cloudFoundry: CLOUD-FOUNDRY-NAME
+      cloudFoundryAPIRef:
+        name: CLOUD-FOUNDRY-NAME
       org: ORG
       space: SPACE
     ```


### PR DESCRIPTION
I accidentally used an out-dated version of the cloudfoundryspaceentitlement spec.

Part of https://www.pivotaltracker.com/story/show/172380320.

Should this be merged to any other branches? No, only for v0.4.0
